### PR TITLE
 Update organisation switcher link logic

### DIFF
--- a/app/views/components/organisation-switcher/index.html
+++ b/app/views/components/organisation-switcher/index.html
@@ -23,16 +23,22 @@
           href: '#'
         }
       }) }}
-  
+
       <br>
-      
+
       <h2 class="govuk-heading-l">Example 2</h2>
       {{ mojOrganisationSwitcher({
         text: 'HMP Brixton, HMP/YOI Feltham, HMP/YOI Isis, HMP Pentonville, HMP Thameside, HMP Wandsworth, HMP Wormwood Scrubs',
         link: {
-          text: "Change prisons",
           href: '#'
         }
+      }) }}
+
+      <br>
+
+      <h2 class="govuk-heading-l">Example 3</h2>
+      {{ mojOrganisationSwitcher({
+        text: 'HMP Brixton'
       }) }}
 
     </div>

--- a/src/moj/components/organisation-switcher/template.njk
+++ b/src/moj/components/organisation-switcher/template.njk
@@ -1,8 +1,12 @@
-<div {% if params.id %}id="{{ params.id }}"{% endif -%} class="moj-organisation-nav {{- ' ' + params.classes if params.classes}}" aria-label="{{ params.label | default('Organisation switcher') }}" {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="moj-organisation-nav {{- ' ' + params.classes if params.classes }}" aria-label="{{ params.label | default('Organisation switcher') }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <div class="moj-organisation-nav__title">
     {{- params.html | safe if params.html else params.text -}}
   </div>
-  <a {% if params.link.id %}id="{{ params.link.id }}"{% endif -%} href="{{ params.link.href }}" class="moj-organisation-nav__link {{- ' ' + params.link.classes if params.link.classes}}" {%- for attribute, value in params.link.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
-    {{- params.link.html | safe if params.link.html else params.link.text | default('Change organisation') -}}
-  </a>
+
+  {% if params.link %}
+    {%- set linkText = params.link.text | default('Change organisation') -%}
+    <a {%- if params.link.id %} id="{{ params.link.id }}"{% endif %} href="{{ params.link.href }}" class="moj-organisation-nav__link {{- ' ' + params.link.classes if params.link.classes }}" {%- for attribute, value in params.link.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      {{- linkText -}}
+    </a>
+  {% endif %}
 </div>


### PR DESCRIPTION

### Identify the bug

#66 

### Description of the change

Only display the organisation switcher link if a link object is
passed to the component.

This prevents an empty link tag being output to the source if there
is no link destination.

This change still supports the fallback text as long as a link `href`
is supplied.

It also updates the example to show how the component will look
without a change link and with the fallback link text.

### Possible drawbacks

This removes the ability to add HTML inside the link element. I can't see why we would want to accept HTML inside this particular element though and it felt like this implementation may have been copied from other components that may have a specific need for it. Where possible we should be limiting the amount of locations input can be marked as safe and displayed as HTML.

## What it looks like now

With this configuration:
```
{{ mojOrganisationSwitcher({
  text: 'HMP Brixton'
}) }}
```

It will display:
![image](https://user-images.githubusercontent.com/3327997/62639023-9161f780-b936-11e9-8949-ab43cd49d50d.png)

Fixes #66 